### PR TITLE
Fix: Popover will be Form Sheet in landscape on Plus-size iPhones

### DIFF
--- a/KUIPopOver/Classes/KUIPopOver.swift
+++ b/KUIPopOver/Classes/KUIPopOver.swift
@@ -185,6 +185,9 @@ private final class KUIPopOverDelegation: NSObject, UIPopoverPresentationControl
         return .none
     }
     
+    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+        return .none
+    }
 }
 
 private extension UIViewController {


### PR DESCRIPTION
Before merging this Pull Request:
![](https://user-images.githubusercontent.com/1333214/32408080-9932e320-c1d5-11e7-8b15-d9d7f7ed864c.gif)

After:
![](https://user-images.githubusercontent.com/1333214/32408081-a0bffd76-c1d5-11e7-9b72-089cbfdbc0e8.gif)

See also:
- https://stackoverflow.com/a/30481565/8810634
- https://github.com/soberman/ARSPopover/issues/6