### PR TITLE
Modify showPopoverWithNavigationController method name

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -58,7 +58,7 @@ class ViewController: UIViewController {
     @IBAction func onPopOverNavigationViewController(_ sender: UIButton) {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let viewController = storyboard.instantiateViewController(withIdentifier: "CustomPushViewController") as! CustomPushViewController
-        viewController.showPopover(withNavigationController: sender, shouldDismissOnTap: false)
+        viewController.showPopoverWithNavigationController(sourceView: sender, shouldDismissOnTap: false)
     }
 }
 

--- a/KUIPopOver/Classes/KUIPopOver.swift
+++ b/KUIPopOver/Classes/KUIPopOver.swift
@@ -128,7 +128,7 @@ extension KUIPopOverUsable where Self: UIViewController {
         rootViewController?.present(self, animated: true, completion: completion)
     }
     
-    public func showPopover(withNavigationController sourceView: UIView, sourceRect: CGRect? = nil, shouldDismissOnTap: Bool = true, completion: ShowPopoverCompletion? = nil) {
+    public func showPopoverWithNavigationController(sourceView: UIView, sourceRect: CGRect? = nil, shouldDismissOnTap: Bool = true, completion: ShowPopoverCompletion? = nil) {
         let naviController = popOverUsableNavigationController
         naviController.popoverPresentationController?.sourceView = sourceView
         naviController.popoverPresentationController?.sourceRect = sourceRect ?? sourceView.bounds
@@ -142,7 +142,7 @@ extension KUIPopOverUsable where Self: UIViewController {
         rootViewController?.present(self, animated: true, completion: completion)
     }
     
-    public func showPopover(withNavigationController barButtonItem: UIBarButtonItem, shouldDismissOnTap: Bool = true, completion: ShowPopoverCompletion? = nil) {
+    public func showPopoverWithNavigationController(barButtonItem: UIBarButtonItem, shouldDismissOnTap: Bool = true, completion: ShowPopoverCompletion? = nil) {
         let naviController = popOverUsableNavigationController
         naviController.popoverPresentationController?.barButtonItem = barButtonItem
         KUIPopOverDelegation.shared.shouldDismissOnOutsideTap = shouldDismissOnTap

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ public func dismissPopover(animated: Bool, completion: DismissPopoverCompletion?
 
 ```swift
 public func showPopover(sourceView: UIView, sourceRect: CGRect?, completion: ShowPopoverCompletion?)
-public func showPopover(withNavigationController sourceView: UIView, sourceRect: CGRect?, completion: ShowPopoverCompletion?)
+public func showPopoverWithNavigationController(sourceView: UIView, sourceRect: CGRect?, completion: ShowPopoverCompletion?)
 public func showPopover(barButtonItem: UIBarButtonItem, completion: ShowPopoverCompletion?)
-public func showPopover(withNavigationController barButtonItem: UIBarButtonItem, completion: ShowPopoverCompletion?)
+public func showPopoverWithNavigationController(barButtonItem: UIBarButtonItem, completion: ShowPopoverCompletion?)
 public func dismissPopover(animated: Bool, completion: DismissPopoverCompletion?)
 ```
 
@@ -113,7 +113,7 @@ customViewController.showPopover(sourceView: sender, sourceRect: sender.bounds)
 customViewController.showPopover(barButtonItem: sender)
 
 // with NavigationController
-customViewController.showPopover(withNavigationController: sender, sourceRect: sender.bounds)
+customViewController.showPopoverWithNavigationController(sourceView: sender, sourceRect: sender.bounds)
 
 customViewController.dismissPopover(animated: true)
 customViewController.dismissPopover(animated: true, completion: {


### PR DESCRIPTION
I think `func showPopover(withNavigationController sourceView: UIView)` can be confusing because it seems to have to pass a root view of navigationController.

![image](https://user-images.githubusercontent.com/11647461/48068685-d2e23c80-e216-11e8-8b59-e16869e2eca4.png)

Therefore, I changed the function name to 
`func showPopoverWithNavigationController(sourceView: UIView?)`.