### PR TITLE
Add done button for CustomPushViewController in example

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -159,7 +159,7 @@ class CustomPushViewController: UIViewController, KUIPopOverUsable {
         super.viewDidLoad()
         preferredContentSize = size
         navigationItem.title = size.debugDescription
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Done", style: .done, target: self, action: #selector(onCloseButton(_:)))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Done", style: .done, target: self, action: #selector(onDoneButton(_:)))
     }
     
     @IBAction func onPushViewController(_ sender: UIButton) {
@@ -169,7 +169,7 @@ class CustomPushViewController: UIViewController, KUIPopOverUsable {
     }
     
     @objc
-    private func onCloseButton(_ sender: UIButton) {
+    private func onDoneButton(_ sender: UIButton) {
         dismissPopover(animated: true)
     }
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -159,6 +159,7 @@ class CustomPushViewController: UIViewController, KUIPopOverUsable {
         super.viewDidLoad()
         preferredContentSize = size
         navigationItem.title = size.debugDescription
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Done", style: .done, target: self, action: #selector(onCloseButton(_:)))
     }
     
     @IBAction func onPushViewController(_ sender: UIButton) {
@@ -167,4 +168,8 @@ class CustomPushViewController: UIViewController, KUIPopOverUsable {
         navigationController?.pushViewController(viewController, animated: true)
     }
     
+    @objc
+    private func onCloseButton(_ sender: UIButton) {
+        dismissPopover(animated: true)
+    }
 }


### PR DESCRIPTION
In example, we can't dismiss `CustomPushViewController` because `shouldDismissOnTap` is `false`.
```swift
let viewController = storyboard.instantiateViewController(withIdentifier: "CustomPushViewController") as! CustomPushViewController
viewController.showPopoverWithNavigationController(sourceView: sender, shouldDismissOnTap: false)
```

Therefore, I just add Done button.
<img src="https://user-images.githubusercontent.com/11647461/62958702-3f3b3d80-be32-11e9-917a-70241c79feb7.png" width=200>
